### PR TITLE
Fixed PDF not updating when changing template

### DIFF
--- a/dokumentgenerator/src/components/SelectTemplate.js
+++ b/dokumentgenerator/src/components/SelectTemplate.js
@@ -11,7 +11,7 @@ class SelectTemplate extends Component {
 
     handleChange(event) {
         let selected = event.target.value;
-        this.props.setTemplateType(selected);
+        this.props.setTemplateType(selected, this.props.previewFormat);
     }
 
     render() {
@@ -37,11 +37,12 @@ class SelectTemplate extends Component {
 const mapStateToProps = state => ({
     ...state,
     selectedTemplate: state.templateReducer.selectedTemplate,
-    templates: state.templateReducer.templateNames
+    templates: state.templateReducer.templateNames,
+    previewFormat: state.templateReducer.previewFormat
 });
 
 const mapDispatchToProps = dispatch => ({
-    setTemplateType: (selected) => dispatch(selectedTemplate(selected)),
+    setTemplateType: (selected, format) => dispatch(selectedTemplate(selected, format)),
     getTemplateNames: () => dispatch(getTemplateNames())
 });
 

--- a/dokumentgenerator/src/redux/actions/templateAction.js
+++ b/dokumentgenerator/src/redux/actions/templateAction.js
@@ -15,16 +15,16 @@ export const GET_TEST_DATA_NAMES = 'GET_TEST_SET_NAMES';
 export const SET_SELECTED_TEST_DATA = 'SET_SELECTED_TEST_DATA';
 
 
-export const selectedTemplate = (selected) => dispatch => {
+export const selectedTemplate = (selected, format) => dispatch => {
     dispatch({
         type: SELECTED_TEMPLATE,
         payload: selected
     });
     if(selected===""){
         dispatch(clearEditorAndPreview());
-    } else { 
+    } else {
         dispatch(getTemplateContentInMarkdown(selected));
-        dispatch(getTestDataNames(selected))
+        dispatch(getTestDataNames(selected, format))
     }
 };
 
@@ -111,13 +111,13 @@ export const clearEditorAndPreview = () => dispatch => {
     })
 };
 
-export const getTestDataNames = (name) => dispatch => {
+export const getTestDataNames = (name, format) => dispatch => {
     axios.get("maler/" + name + "/testdata").then(res => {
         dispatch({
             type: GET_TEST_DATA_NAMES,
             payload: res.data
         });
-        dispatch(getTemplateContentInHTML(name, res.data[0]))
+        dispatch(getTemplateContentInHTML(name, res.data[0], "", format))
     }
     )
 };


### PR DESCRIPTION
Bug due to `format` never being sent during template update.